### PR TITLE
fix type-check

### DIFF
--- a/project_template/{{cookiecutter.project_repo_name}}/Makefile
+++ b/project_template/{{cookiecutter.project_repo_name}}/Makefile
@@ -7,4 +7,4 @@ test:
 	forge test
 
 type-check:
-	cd .. && mypy -p $(shell basename $(CURDIR)) --ignore-missing-imports --check-untyped-defs --install-types --python-version 3.8
+	cd .. && mypy -p $(shell basename $(CURDIR)) --ignore-missing-imports --check-untyped-defs --python-version 3.8

--- a/project_template/{{cookiecutter.project_repo_name}}/Makefile
+++ b/project_template/{{cookiecutter.project_repo_name}}/Makefile
@@ -7,4 +7,4 @@ test:
 	forge test
 
 type-check:
-	cd .. && mypy -p $(shell basename $(CURDIR))--ignore-missing-imports --python-version 3.8
+	cd .. && mypy -p $(shell basename $(CURDIR)) --ignore-missing-imports --check-untyped-defs --install-types --python-version 3.8


### PR DESCRIPTION
1. Fixes missing space between project name and first kwarg
2. adds `--check-untyped-defs` for checking functions inside functions (important for django `service.py`)